### PR TITLE
Upgrade AWS utils library

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.5"
+  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.11"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "2.2.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.2"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "2.27.2"

--- a/src/main/scala/uk/gov/nationalarchives/ecr/scan/ImageUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/ecr/scan/ImageUtils.scala
@@ -1,9 +1,11 @@
 package uk.gov.nationalarchives.ecr.scan
 
+import java.net.URI
 import java.nio.charset.Charset
 
 import cats.effect.IO
 import cats.implicits._
+import com.typesafe.config.ConfigFactory
 import software.amazon.awssdk.services.ecr.model.{DescribeImagesResponse, DescribeRepositoriesResponse, StartImageScanResponse}
 import uk.gov.nationalarchives.aws.utils.Clients.ecr
 import uk.gov.nationalarchives.aws.utils.ECRUtils
@@ -12,7 +14,8 @@ import uk.gov.nationalarchives.aws.utils.ECRUtils.EcrImage
 import scala.jdk.CollectionConverters._
 
 class ImageUtils() {
-  val utils: ECRUtils = ECRUtils(ecr)
+  private val ecrClient = ecr(URI.create(ConfigFactory.load.getString("ecr.endpoint")))
+  val utils: ECRUtils = ECRUtils(ecrClient)
 
   def listRepositories: IO[DescribeRepositoriesResponse] = utils.listRepositories()
 


### PR DESCRIPTION
The signature of the ECR utils class has changed so that it doesn't make assumptions about how the client app stores the config, so pass in the new endpoint parameter.