### PR TITLE
Use the correct role name.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Configure AWS credentials for Lambda
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/TDRGithubLambdaRoleMgmt
+          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/TDRGithubActionsDeployLambdaMgmt
           aws-region: eu-west-2
           role-session-name: ECRLogin
       - name: Deploy to lambda


### PR DESCRIPTION
I don't know where I got this role from but it isn't defined anywhere
and it doesn't exist.
The TDRGithubLambdaRoleMgmt role should have permissions to deploy.
